### PR TITLE
Adding support for HL78xx custom commands

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ This setup configuration includes the package metadata, such as the name, versio
 from setuptools import setup, find_packages
 import os
 
-version = "0.1.1"
+version = "0.1.2"
 # User-friendly description from README.md
 current_directory = os.path.dirname(os.path.abspath(__file__))
 try:

--- a/sierra_status/src/cli.py
+++ b/sierra_status/src/cli.py
@@ -23,12 +23,12 @@ def main() -> None:
     optional.add_argument("-m", "--model", help="Model of the device to add to filename (e.g., EM9191 or EM7455)", default="")
     optional.add_argument("-v", "--verbose", help="Enable verbose output", action="store_true")
     optional.add_argument("-s", "--search", help="Search for network using AT!COPS=?", action="store_true")
-
+    optional.add_argument("-b", "--baudrate", help="Baudrate to use for serial communication (default: 115200)", default=115200, type=int)
     args = parser.parse_args()
 
     log_level = logging.DEBUG if args.verbose else logging.INFO
     logging.basicConfig(level=log_level)
-    usb_handle.start_process(args.port, args.model.lower(), log_level, args.search)
+    usb_handle.start_process(args.port, args.model.lower(), log_level, args.search, args.baudrate)
 
 if __name__ == "__main__":
         main()


### PR DESCRIPTION
- Adding a new set of commands to support HL78xx LPWA modules.
- Adding a new CLI option to handle the baud rate (default 115200) and update all relevant methods
-  refactor method name from 'em' to 'module'
- adding and updating the test per new changes.
- update the version to 0.1.2

close #1 
